### PR TITLE
Initial test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install-main-extension: | _check_virtualenv	## Install the main extension (the o
 	./scripts/install-main-extension.sh
 
 services:	## Run all the CKAN services from docker compose (database, Solr and Redis)
-	docker compose up --no-attach ckan_solr --no-attach ckan_redis && \
+	docker compose up --no-attach ckan_solr --no-attach ckan_redis
 
 run:	## Run the CKAN Docker container (Run `make build` first to create the image. Requires services running, see `make services`)
 	docker run --env-file .kamal/secrets.local --name ckan-example --network host ckan-example:latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make services
 
 In a new console, run CKAN:
 ```
-python -m venv .venv
+python3.11 -m venv .venv
 source .venv/bin/activate
 
 make install-os-deps

--- a/scripts/install-ckan.sh
+++ b/scripts/install-ckan.sh
@@ -4,7 +4,9 @@
 CKAN_INSTALL_TAG=ckan-2.10.5
 
 echo "------ Checking out upstream CKAN code into ckan folder ------"
-git clone -q -b "$CKAN_INSTALL_TAG" "https://github.com/ckan/ckan.git" "ckan"
+if [ ! -d "ckan" ] ; then
+    git clone -q -b "$CKAN_INSTALL_TAG" "https://github.com/ckan/ckan.git" "ckan"
+fi
 cd ckan
 
 echo "------ Applying local patches to upstream CKAN code ------"


### PR DESCRIPTION
My initial tests
# Load Test Logs for Local Environment Setup

### Python Version
The environment creation script does not specify the Python version to be used.  
The default version on Ubuntu is Python 3.8, but it could potentially be 3.10 or 3.11.

---

## Commands and Observations

### Step 1: `make services`
```bash
make services
docker compose up --no-attach ckan_solr --no-attach ckan_redis && \
/bin/sh: 2: Syntax error: end of file unexpected
make: *** [Makefile:19: services] Error 2
```

**Resolution:**  
Removed the trailing `&& \` from the command.

---

### Step 2: `make install-os-deps`

**Note:** As a developer, I'm not thrilled about installing dependencies directly into my main operating system.  
For instance, if I need QSV 1.20 for another project, potential conflicts could arise. This preference makes me lean towards a fully isolated environment at the operating system level.

**Execution Command:**  
```bash
./scripts/install-os-deps.sh
```

**Output:**  
```plaintext
Installing OS dependencies
Reading package lists... Done
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
W: Problem unlinking the file /var/cache/apt/pkgcache.bin - RemoveCaches (13: Permission denied)
W: Problem unlinking the file /var/cache/apt/srcpkgcache.bin - RemoveCaches (13: Permission denied)
make: *** [Makefile:7: install-os-deps] Error 100
```

**Resolution:**  
Ran the command with `sudo`:
```bash
sudo make install-os-deps
```
It worked.

---

### Step 3: Virtual Environment Activation

**Command:**  
```bash
source ~/3envs/bcie310/bin/activate
```

**Prompt:**  
```bash
(bcie310) vlad:/data/dev/okf/bcie/ckan-example 09:56
(main)$ make install-ckan
```

**Error:**  
```plaintext
Virtual environment not activated - create one at .venv folder and activate it.
make: *** [Makefile:34: _check_virtualenv] Error 1
```

**Analysis:**  
Although the virtual environment is activated, the script doesn't recognize it because it isn't located in the `.venv` directory.  
I prefer not to have the `.venv` folder inside the project directory, as it makes the IDE heavy when searching files. While this can be mitigated by ignoring the folder, such configurations don’t always work perfectly.

**Resolution:**  
Moved to `.venv`. It worked, mostly.

---

### Step 4: Missing Python Header File

**Error:**  
```plaintext
./psycopg/psycopg.h:35:10: fatal error: Python.h: No such file or directory
 35 | #include <Python.h>
    |          ^~~~~~~~~~
```

**Analysis:**  
At this point I go to OS install script to fix it and realize we expect python 3.11

**Resolution:**  
Recreate a python 3.11 venv

---

### Step 5: CKAN Installation

**Command:**  
```bash
make install-ckan
```

**Output:**  
```plaintext
./scripts/install-ckan.sh
------ Checking out upstream CKAN code into ckan folder ------
fatal: destination path 'ckan' already exists and is not an empty directory.
make: *** [Makefile:10: install-ckan] Error 128
```

**Resolution:**  
No additional action taken here, as the existing folder conflicts need resolution.

---

### Step 6: Extensions Installation

**Commands:**  
```bash
make install-extensions  # OK
make install-main-extension  # OK
```

---

### Step 7: Running CKAN

**Command:**  
```bash
ckan run
```

It runs but I get 500 errors

**Error:**  
```plaintext
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedTable) relation "group" does not exist
LINE 2: FROM "group"
```

**Analysis:**  
The database schema is incomplete or has not been properly initialized.
